### PR TITLE
Replace bitnami image references with bitnamilegacy

### DIFF
--- a/postgresql-cluster-pgpool/postgres.yml
+++ b/postgresql-cluster-pgpool/postgres.yml
@@ -69,7 +69,7 @@ postgres-common:
       protocol: tcp
   containers:
     postgres:
-      image: bitnami/postgresql-repmgr
+      image: bitnamilegacy/postgresql-repmgr
       image-tag: <- $postgres_version default("14")
 
 db1:
@@ -161,7 +161,7 @@ dbpool:
       value: 'yes'
   containers:
     pgpool:
-      image: docker.io/bitnami/pgpool
+      image: docker.io/bitnamilegacy/pgpool
       image-tag: <- $pgpool_image_tag default("4")
   services:
     postgres-pgpool:

--- a/postgresql-cluster/postgres.yml
+++ b/postgresql-cluster/postgres.yml
@@ -69,7 +69,7 @@ postgres-common:
       protocol: tcp
   containers:
     postgres:
-      image: bitnami/postgresql-repmgr
+      image: bitnamilegacy/postgresql-repmgr
       image-tag: <- $postgres_version default("14")
 
 db1:

--- a/postgresql-extended/postgres.yml
+++ b/postgresql-extended/postgres.yml
@@ -37,7 +37,7 @@ db:
       path: <- `${monk-volume-path}/postgresql`
   containers:
     postgres:
-      image: bitnami/postgresql
+      image: bitnamilegacy/postgresql
       image-tag: latest
       paths:
         - <- `${monk-volume-path}/postgresql:/bitnami/postgresql`


### PR DESCRIPTION
This PR replaces 'image: docker.io/bitnami/' and 'image: bitnami/' with their 'bitnamilegacy' equivalents, as per organization migration.