### PR TITLE
[fix] set fixed version=17 for postgresql base image

### DIFF
--- a/postgresql/postgres.yml
+++ b/postgresql/postgres.yml
@@ -22,7 +22,7 @@ base:
   containers:
     postgres:
       image: postgres
-      image-tag: latest
+      image-tag: 17
 
 db:
   defines: runnable
@@ -37,6 +37,7 @@ db:
       host-port: 5432
   containers:
     postgres:
+      # postgresql 18+ uses /var/lib/postgresql instead of /var/lib/postgresql/data`
       paths:
         - <- `${monk-volume-path}/postgresql:/var/lib/postgresql/data`
   variables:


### PR DESCRIPTION
This pull request updates the PostgreSQL container configuration to improve compatibility with newer PostgreSQL versions. The most important changes are:

**PostgreSQL Version Update:**

* Changed the `image-tag` for the `postgres` container from `latest` to `17` in `postgresql/postgres.yml`, ensuring the environment uses a specific PostgreSQL version.

**Container Path Configuration:**

* Added a comment in `postgresql/postgres.yml` noting that PostgreSQL 18+ uses `/var/lib/postgresql` instead of `/var/lib/postgresql/data`, clarifying future upgrade requirements.