### PR TITLE
fix: use string for postgres image-tag

### DIFF
--- a/postgresql/postgres.yml
+++ b/postgresql/postgres.yml
@@ -22,7 +22,7 @@ base:
   containers:
     postgres:
       image: postgres
-      image-tag: 17
+      image-tag: "17"
 
 db:
   defines: runnable


### PR DESCRIPTION
This pull request makes a minor update to the `postgresql/postgres.yml` configuration file, changing the `image-tag` value for the `postgres` container from an integer to a string format. This ensures better compatibility and consistency in YAML parsing.